### PR TITLE
Fix for some of the issues discussed in issue #33

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -90,7 +90,16 @@ IncomingForm.prototype.parse = function(req, cb) {
     var fields = {}, files = {};
     this
       .on('field', function(name, value) {
-        fields[name] = value;
+        // check for arrays
+        if (name.indexOf("[]") === -1) { // not an array
+          fields[name] = value;
+        } else { // is an array
+          name = name.replace("[]","");
+          if (typeof fields[name] === "undefined") {
+            fields[name] = [];
+          }
+          fields[name].push(value);
+        }
       })
       .on('file', function(name, file) {
         files[name] = file;

--- a/test/simple/test-incoming-form.js
+++ b/test/simple/test-incoming-form.js
@@ -199,6 +199,8 @@ test(function parse() {
         fn('field1', 'foo');
         fn('field1', 'bar');
         fn('field2', 'nice');
+        fn('fieldArray[]', 'first');
+        fn('fieldArray[]', 'second');
       }
 
       if (event == 'file') {
@@ -214,7 +216,7 @@ test(function parse() {
     });
 
     form.parse(REQ, gently.expect(function parseCbOk(err, fields, files) {
-      assert.deepEqual(fields, {field1: 'bar', field2: 'nice'});
+      assert.deepEqual(fields, {field1: 'bar', field2: 'nice', fieldArray: ['first','second']});
       assert.deepEqual(files, {file1: '2', file2: '3'});
     }));
 


### PR DESCRIPTION
I've added support for field arrays as discussed in felixge/node-formidable#33

This will turn any *field* (not file) with a name ending with "[]" into an array of all the fields with same name.

Fields with the same name but with no "[]" suffix will still overwrite each other.

The above functionality is supported by the tests that I added in "test/simple/test-incoming-form.js".

The way this has been implemented adds minimal complexity to the module, and adds much needed functionality that is supported by every mainstream HTTP parser for Node as well as other languages.

I haven't added the ability to do the same thing with files because you expressed concern against it, but I can see it being another needed feature (I've implemented bulk uploaders in other languages using file arrays). The implementation would be very similar to how I've done this one.