### PR TITLE
emit 'error' when write to WriteStream failed

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -46,6 +46,10 @@ File.prototype._backwardsCompatibility = function() {
 
 File.prototype.open = function() {
   this._writeStream = new WriteStream(this.path);
+  var self = this;
+  this._writeStream.on('error', function (err) {
+    self.emit('writeError', err);
+  });
 };
 
 File.prototype.write = function(buffer, cb) {

--- a/lib/file.js
+++ b/lib/file.js
@@ -45,10 +45,10 @@ File.prototype._backwardsCompatibility = function() {
 };
 
 File.prototype.open = function() {
-  this._writeStream = new WriteStream(this.path);
   var self = this;
-  this._writeStream.on('error', function (err) {
-    self.emit('writeError', err);
+  self._writeStream = new WriteStream(this.path);
+  self._writeStream.on('error', function (err) {
+    self.emit('error', err);
   });
 };
 

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -202,6 +202,10 @@ IncomingForm.prototype.handlePart = function(part) {
     hash: self.hash
   });
 
+  file.on('writeError', function(error) {
+    self._error(new Error(error));
+  });
+
   this.emit('fileBegin', part.name, file);
 
   file.open();

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -202,15 +202,17 @@ IncomingForm.prototype.handlePart = function(part) {
     hash: self.hash
   });
 
-  file.on('writeError', function(error) {
-    self._error(new Error(error));
-  });
+
 
   this.emit('fileBegin', part.name, file);
 
   file.open();
   this.openedFiles.push(file);
-
+  
+  file.on('error', function(error) {
+    self._error(error);
+  });
+  
   part.on('data', function(buffer) {
     self.pause();
     file.write(buffer, function() {

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -263,8 +263,15 @@ IncomingForm.prototype._error = function(err) {
   this.emit('error', err);
 
   this.openedFiles.forEach(function(file) {
-    file._writeStream.destroy();
-    setTimeout(fs.unlink, 0, file.path);
+        file._writeStream.destroy();
+        
+        setTimeout(function() {
+            try{
+                fs.unlink();
+            } catch (e) {
+                console.log("Error unlinking file: " + err);
+            }
+        }, 0, file.path);
   });
 };
 


### PR DESCRIPTION
We tried to write to a non-existing directory, which resulted in an uncaught exception. I added an error handler for WriteStream, so 'error' is emitted when writing the file failed. 
