### PR TITLE
Use the new node "buf.write" api.

### DIFF
--- a/lib/multipart_parser.js
+++ b/lib/multipart_parser.js
@@ -58,8 +58,8 @@ MultipartParser.stateToString = function(stateNumber) {
 
 MultipartParser.prototype.initWithBoundary = function(str) {
   this.boundary = new Buffer(str.length+4);
-  this.boundary.write('\r\n--', 'ascii', 0);
-  this.boundary.write(str, 'ascii', 4);
+  this.boundary.write('\r\n--', 0, 'ascii');
+  this.boundary.write(str, 4, 'ascii');
   this.lookbehind = new Buffer(this.boundary.length+8);
   this.state = S.START;
 


### PR DESCRIPTION
`.write(string, encoding, offset, length)` is deprecated.
Use `write(string[, offset[, length]][, encoding])` instead.

Since the node v0.8 the api has been changed.

http://nodejs.org/docs/v0.8.0/api/buffer.html#buffer_buf_write_string_offset_length_encoding