### PR TITLE
fix deprecated Buffer.write call for node 0.11.x

### DIFF
--- a/lib/multipart_parser.js
+++ b/lib/multipart_parser.js
@@ -58,8 +58,8 @@ MultipartParser.stateToString = function(stateNumber) {
 
 MultipartParser.prototype.initWithBoundary = function(str) {
   this.boundary = new Buffer(str.length+4);
-  this.boundary.write('\r\n--', 'ascii', 0);
-  this.boundary.write(str, 'ascii', 4);
+  this.boundary.write('\r\n--', 0, 'ascii');
+  this.boundary.write(str, 4, 'ascii');
   this.lookbehind = new Buffer(this.boundary.length+8);
   this.state = S.START;
 

--- a/lib/multipart_parser.js
+++ b/lib/multipart_parser.js
@@ -58,8 +58,8 @@ MultipartParser.stateToString = function(stateNumber) {
 
 MultipartParser.prototype.initWithBoundary = function(str) {
   this.boundary = new Buffer(str.length+4);
-  this.boundary.write('\r\n--', 0, 'ascii');
-  this.boundary.write(str, 4, 'ascii');
+  this.boundary.write('\r\n--', 0);
+  this.boundary.write(str, 4);
   this.lookbehind = new Buffer(this.boundary.length+8);
   this.state = S.START;
 


### PR DESCRIPTION
Saw this popping up a bit using node v0.11.14:

`.write(string, encoding, offset, length) is deprecated. Use write(string[, offset[, length]][, encoding]) instead.`

Tested with node v0.10.33 and v0.11.14, using npm test.

