### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
   "bugs": {
     "url": "http://github.com/felixge/node-formidable/issues"
   },
-  "optionalDependencies": {}
+  "optionalDependencies": {},
+  "license": "MIT"
 }


### PR DESCRIPTION
Missing license from here https://www.npmjs.com/package/formidable
