### PR TITLE
Improvement on Content-Disposition parsing

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -352,7 +352,8 @@ IncomingForm.prototype._initMultipart = function(boundary) {
     headerField = headerField.toLowerCase();
     part.headers[headerField] = headerValue;
 
-    var m = headerValue.match(/\bname="([^"]+)"/i);
+    // matches either a quoted-string or a token (RFC 2616 section 19.5.1)
+    var m = headerValue.match(/\bname=("([^"]+)"|([^\(\)<>@,;:\\"\/\[\]\?=\{\}\s\t/]+))/i);
     if (headerField == 'content-disposition') {
       if (m) {
         part.name = m[1];
@@ -421,7 +422,8 @@ IncomingForm.prototype._initMultipart = function(boundary) {
 };
 
 IncomingForm.prototype._fileName = function(headerValue) {
-  var m = headerValue.match(/\bfilename="(.*?)"($|; )/i);
+  // matches either a quoted-string or a token (RFC 2616 section 19.5.1)
+  var m = headerValue.match(/\bfilename=("(.*?)"|([^\(\)<>@,;:\\"\/\[\]\?=\{\}\s\t/]+))($|;\s)/i);
   if (!m) return;
 
   var filename = m[1].substr(m[1].lastIndexOf('\\') + 1);

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -353,7 +353,7 @@ IncomingForm.prototype._initMultipart = function(boundary) {
     part.headers[headerField] = headerValue;
 
     // matches either a quoted-string or a token (RFC 2616 section 19.5.1)
-    var m = headerValue.match(/\bname=("([^"]+)"|([^\(\)<>@,;:\\"\/\[\]\?=\{\}\s\t/]+))/i);
+    var m = headerValue.match(/\bname=("([^"]*)"|([^\(\)<>@,;:\\"\/\[\]\?=\{\}\s\t/]+))/i);
     if (headerField == 'content-disposition') {
       if (m) {
         part.name = m[1];

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -356,7 +356,7 @@ IncomingForm.prototype._initMultipart = function(boundary) {
     var m = headerValue.match(/\bname=("([^"]*)"|([^\(\)<>@,;:\\"\/\[\]\?=\{\}\s\t/]+))/i);
     if (headerField == 'content-disposition') {
       if (m) {
-        part.name = m[1];
+        part.name = m[2] || m[3] || '';
       }
 
       part.filename = self._fileName(headerValue);
@@ -426,7 +426,8 @@ IncomingForm.prototype._fileName = function(headerValue) {
   var m = headerValue.match(/\bfilename=("(.*?)"|([^\(\)<>@,;:\\"\/\[\]\?=\{\}\s\t/]+))($|;\s)/i);
   if (!m) return;
 
-  var filename = m[1].substr(m[1].lastIndexOf('\\') + 1);
+  var match = m[2] || m[3] || '';
+  var filename = match.substr(match.lastIndexOf('\\') + 1);
   filename = filename.replace(/%22/g, '"');
   filename = filename.replace(/&#([\d]{4});/g, function(m, code) {
     return String.fromCharCode(code);


### PR DESCRIPTION
As the RFC 2616 section `19.5.1 (Content-Disposition)` says that a parameter value can be a quoted string or a token. The section `2.2 (Basic Rules)` clearly says that a token is not a quoted string.

Now the parsing of the "name" and "filename" parameter values support only quoted string, and modern client-side frameworks tend to omit the quotes when not necessary, though still respecting the standard.

Moreover, the "name" parameter value can be empty, because the specification says the quoted string can be empty. So I replaced the + in the regular expression by a * symbol. The "filename" regular expression is already correct in term of character count matching.

Note that the new regular expressions should keep the correct amount of capturing groups, matching either one or the other.

I don't know how to create and provide unit tests (fixture files ?) for this pull request, but if it is necessary, please let me know and I'll see what can I do.

Thank you.
