### PR TITLE
Access WriteStream of fs during runtime instead of include time

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -1,7 +1,7 @@
 if (global.GENTLY) require = GENTLY.hijack(require);
 
 var util = require('util'),
-    WriteStream = require('fs').WriteStream,
+    fs = require('fs'),
     EventEmitter = require('events').EventEmitter,
     crypto = require('crypto');
 
@@ -31,7 +31,7 @@ module.exports = File;
 util.inherits(File, EventEmitter);
 
 File.prototype.open = function() {
-  this._writeStream = new WriteStream(this.path);
+  this._writeStream = new fs.WriteStream(this.path);
 };
 
 File.prototype.toJSON = function() {


### PR DESCRIPTION
This adds compatibility with [mock-fs](https://github.com/tschaub/mock-fs), which overrides these methods and expects modules to access them thereafter. This is merely a suggestion, as I don't know if you support making changes in order to support such things. However, I find the mock-fs module to be incredibly useful and would love to have it supported.
