### PR TITLE
Update buffer.write order of arguments

### DIFF
--- a/test/legacy/integration/test-multipart-parser.js
+++ b/test/legacy/integration/test-multipart-parser.js
@@ -50,7 +50,7 @@ Object.keys(fixtures).forEach(function(name) {
     endCalled = true;
   };
 
-  buffer.write(fixture.raw, 'binary', 0);
+  buffer.write(fixture.raw, 0, undefined, 'binary');
 
   while (offset < buffer.length) {
     if (offset + CHUNK_LENGTH < buffer.length) {

--- a/test/legacy/simple/test-multipart-parser.js
+++ b/test/legacy/simple/test-multipart-parser.js
@@ -34,7 +34,7 @@ test(function parserError() {
       buffer = new Buffer(5);
 
   parser.initWithBoundary(boundary);
-  buffer.write('--ad', 'ascii', 0);
+  buffer.write('--ad', 0);
   assert.equal(parser.write(buffer), 5);
 });
 


### PR DESCRIPTION
Node 7 throws on 

> Buffer.write(string, encoding, offset[, length]) is no longer supported

the order of arguments has changed.