### PR TITLE
Fix DeprecationWarning's about os.tmpDir()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,7 +87,7 @@ Sets encoding for incoming form fields.
 form.uploadDir = "/my/dir";
 ```
 Sets the directory for placing file uploads in. You can move them later on using
-`fs.rename()`. The default is `os.tmpDir()`.
+`fs.rename()`. The default is `os.tmpdir()`.
 
 ```javascript
 form.keepExtensions = false;
@@ -304,7 +304,7 @@ Emitted when the entire request has been received, and all contained files have 
 * Remove support for Node.js 0.4 & 0.6 (Andrew Kelley)
 * Documentation improvements (Sven Lito, Andre Azevedo)
 * Add support for application/octet-stream (Ion Lupascu, Chris Scribner)
-* Use os.tmpDir() to get tmp directory (Andrew Kelley)
+* Use os.tmpdir() to get tmp directory (Andrew Kelley)
 * Improve package.json (Andrew Kelley, Sven Lito)
 * Fix benchmark script (Andrew Kelley)
 * Fix scope issue in incoming_forms (Sven Lito)

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -26,7 +26,7 @@ function IncomingForm(opts) {
   this.maxFields = opts.maxFields || 1000;
   this.maxFieldsSize = opts.maxFieldsSize || 2 * 1024 * 1024;
   this.keepExtensions = opts.keepExtensions || false;
-  this.uploadDir = opts.uploadDir || os.tmpDir();
+  this.uploadDir = opts.uploadDir || (os.tmpdir && os.tmpdir()) || os.tmpDir();
   this.encoding = opts.encoding || 'utf-8';
   this.headers = null;
   this.type = null;


### PR DESCRIPTION
I have seen this DeprecationWarning in the shell:

```
(node:19532) DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
```

This should fix this issue.

Thank you,

Christian