### PR TITLE
Support webpack electron-renderer mode

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -1,4 +1,6 @@
+/* develblock:start */
 if (global.GENTLY) require = GENTLY.hijack(require);
+/* develblock:end */
 
 var util = require('util'),
     fs = require('fs'),
@@ -16,7 +18,7 @@ function File(properties) {
   this.lastModifiedDate = null;
 
   this._writeStream = null;
-  
+
   for (var key in properties) {
     this[key] = properties[key];
   }

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -1,4 +1,6 @@
+/* develblock:start */
 if (global.GENTLY) require = GENTLY.hijack(require);
+/* develblock:end */
 
 var crypto = require('crypto');
 var fs = require('fs');

--- a/lib/json_parser.js
+++ b/lib/json_parser.js
@@ -1,4 +1,6 @@
+/* develblock:start */
 if (global.GENTLY) require = GENTLY.hijack(require);
+/* develblock:end */
 
 var Buffer = require('buffer').Buffer;
 

--- a/lib/querystring_parser.js
+++ b/lib/querystring_parser.js
@@ -1,4 +1,6 @@
+/* develblock:start */
 if (global.GENTLY) require = GENTLY.hijack(require);
+/* develblock:end */
 
 // This is a buffering parser, not quite as nice as the multipart one.
 // If I find time I'll rewrite this to be fully streaming as well


### PR DESCRIPTION
The hijacked `require` used for testing causes webpack to fail to compile formidable when in electron-renderer mode. This PR adds `/* develblock */` comments which are used by https://www.npmjs.com/package/webpack-strip-block to strip out the offending code during compile.