### PR TITLE
Fix using closed _writeStream when error is occurred (#357)

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -56,6 +56,11 @@ File.prototype.write = function(buffer, cb) {
   if (self.hash) {
     self.hash.update(buffer);
   }
+
+  if (this._writeStream.closed) {
+    return cb();
+  }
+
   this._writeStream.write(buffer, function() {
     self.lastModifiedDate = new Date();
     self.size += buffer.length;


### PR DESCRIPTION
When fileMaxSize reached _error() calls _writeStream.destroy() which turns into unhandled exception.