### PR TITLE
add  fileBegin  try catch callback

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -211,7 +211,11 @@ IncomingForm.prototype.handlePart = function(part) {
     hash: self.hash
   });
 
-  this.emit('fileBegin', part.name, file);
+  try{
+    this.emit('fileBegin', part.name, file);
+  }catch(err){
+    this._error(err);
+  }
 
   file.open();
   this.openedFiles.push(file);


### PR DESCRIPTION
when i  use the middleware `koa-body@4.1` in `koa@2.7`,`koa-body`  depend on the `node-formidable`
```javascript
// this is my code 
const Koa = require('koa');
const koaBody = require('koa-body');
const app = new Koa();
app.use(koaBody({
    multipart:true,
    encoding:'utf-8',
    formidable:{   // this parameter will use in `node-formidable`
        multiples:false,
        uploadDir:path.join(__dirname,'./public/resource/'),
        keepExtensions: true,
        maxFileSize:2 * 1024 * 1024, 
        onFileBegin(name,file){
           // When I limit only upload pictures,i might write it like this
            const fileName = file.name;
            const picReg = /\.(png|jpe?g|gif|svg)$/i;
            if(!picReg.test(fileName)){ 
                throw new Error('only  picture') //throw error will stop  application
            }
        }
    },
    onError(err,ctx){
        ctx.throw(err)
    }
}));
```
Because the exception is  inside `node-formidable`,so i can't solve the problem in `koa-body`.
As shown in the code above,when i  throw error  in `onFileBegin`,it will stop  application,so i wish  add a `try catch` syntax to solve this problem.